### PR TITLE
feat: add auto-zoom transform

### DIFF
--- a/screenvivid/models/utils/transforms.py
+++ b/screenvivid/models/utils/transforms.py
@@ -180,6 +180,107 @@ class Inset(BaseTransform):
             kwargs['input'] = self.inset_frame
         return kwargs
 
+class AutoZoom(BaseTransform):
+    """Automatically zoom around cursor or click positions.
+
+    Parameters
+    ----------
+    move_data : dict | None
+        Mapping of frame index to cursor coordinates as ``(x_rel, y_rel, *_)``.
+    zoom_factor : float
+        The magnification level. A value of ``2.0`` will crop to half the
+        width/height around the focus point and scale back to the original
+        resolution.
+    pan_speed : float
+        Interpolation factor controlling how quickly the viewport moves towards
+        the target position each frame.
+    smoothing : float
+        Interpolation factor applied to the raw cursor positions to reduce
+        jitter.
+    edge_margin : int
+        Minimum number of pixels to keep between the cropped region and the
+        frame edge.
+    keyframes : dict | None
+        Optional mapping of frame index to ``(x_rel, y_rel, zoom)`` tuples
+        providing manual overrides.
+    """
+
+    def __init__(
+        self,
+        move_data=None,
+        zoom_factor: float = 2.0,
+        pan_speed: float = 0.2,
+        smoothing: float = 0.1,
+        edge_margin: int = 0,
+        keyframes=None,
+    ) -> None:
+        super().__init__()
+
+        self.move_data = move_data or {}
+        self.zoom_factor = zoom_factor
+        self.pan_speed = pan_speed
+        self.smoothing = smoothing
+        self.edge_margin = edge_margin
+        self.keyframes = keyframes or {}
+
+        # Internal state for smoothed cursor and viewport center
+        self._smoothed_pos = np.array([0.5, 0.5], dtype=np.float32)
+        self._viewport_center = np.array([0.5, 0.5], dtype=np.float32)
+
+    def __call__(self, **kwargs):
+        if "start_frame" not in kwargs:
+            return kwargs
+
+        frame = kwargs["input"]
+        h, w = frame.shape[:2]
+        idx = kwargs["start_frame"]
+
+        if idx in self.keyframes:
+            # Directly set to keyframe values
+            cx, cy, zf = self.keyframes[idx]
+            self._viewport_center[:] = [cx, cy]
+            self._smoothed_pos[:] = [cx, cy]
+            current_zoom = max(1.0, zf)
+        else:
+            current_zoom = max(1.0, self.zoom_factor)
+
+            if idx in self.move_data:
+                x, y = self.move_data[idx][:2]
+                target = np.array([x, y], dtype=np.float32)
+                self._smoothed_pos = (
+                    (1 - self.smoothing) * self._smoothed_pos
+                    + self.smoothing * target
+                )
+
+            self._viewport_center += (
+                self._smoothed_pos - self._viewport_center
+            ) * self.pan_speed
+
+        crop_w = int(w / current_zoom)
+        crop_h = int(h / current_zoom)
+
+        cx = self._viewport_center[0] * w
+        cy = self._viewport_center[1] * h
+
+        x1 = int(round(cx - crop_w / 2))
+        y1 = int(round(cy - crop_h / 2))
+
+        # Clamp crop coordinates so the region stays within the frame
+        x1 = max(self.edge_margin, min(w - crop_w - self.edge_margin, x1))
+        y1 = max(self.edge_margin, min(h - crop_h - self.edge_margin, y1))
+
+        x2 = x1 + crop_w
+        y2 = y1 + crop_h
+
+        cropped = frame[y1:y2, x1:x2]
+        if (crop_w, crop_h) != (w, h):
+            resized = cv2.resize(cropped, (w, h), cv2.INTER_LINEAR)
+        else:
+            resized = cropped
+
+        kwargs["input"] = resized
+        return kwargs
+
 class Cursor(BaseTransform):
     def __init__(self, move_data, cursors_map, offsets, size=32, scale=1.0):
         super().__init__()

--- a/tests/test_autozoom.py
+++ b/tests/test_autozoom.py
@@ -1,0 +1,88 @@
+import os
+import sys
+import importlib.util
+
+import numpy as np
+import types
+
+fake_cv2 = types.SimpleNamespace()
+
+def _resize(img, size, interpolation=None):
+    from PIL import Image
+
+    return np.array(Image.fromarray(img).resize(size[::-1], Image.BILINEAR))
+
+def _circle(img, center, radius, color, thickness=-1, lineType=None):
+    yy, xx = np.ogrid[:img.shape[0], :img.shape[1]]
+    mask = (xx - center[0]) ** 2 + (yy - center[1]) ** 2 <= radius ** 2
+    img[mask] = color
+    return img
+
+def _addWeighted(a, alpha, b, beta, gamma):
+    return (a * alpha + b * beta + gamma).astype(a.dtype)
+
+fake_cv2.resize = _resize
+fake_cv2.circle = _circle
+fake_cv2.addWeighted = _addWeighted
+fake_cv2.INTER_LINEAR = 1
+fake_cv2.LINE_AA = 1
+
+sys.modules.setdefault("cv2", fake_cv2)
+
+# Import transforms module directly from source tree
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+module_path = os.path.join(
+    os.path.dirname(__file__), "..", "screenvivid", "models", "utils", "transforms.py"
+)
+spec = importlib.util.spec_from_file_location(
+    "screenvivid.models.utils.transforms", module_path
+)
+transforms = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(transforms)
+
+
+def _gradient_frame(width: int, height: int):
+    """Create a frame encoding x in red and y in green channels."""
+    frame = np.zeros((height, width, 3), dtype=np.uint8)
+    frame[:, :, 2] = np.tile(np.arange(width, dtype=np.uint8), (height, 1))
+    frame[:, :, 1] = np.tile(np.arange(height, dtype=np.uint8).reshape(height, 1), (1, width))
+    return frame
+
+
+def test_autozoom_crops_and_clamps():
+    frame = _gradient_frame(100, 100)
+    move_data = {0: (0.8, 0.5, 0, "", 0)}
+
+    zoom = transforms.AutoZoom(
+        move_data=move_data, zoom_factor=2.0, pan_speed=1.0, smoothing=1.0, edge_margin=0
+    )
+    result = zoom(input=frame.copy(), start_frame=0)["input"]
+    center_pixel = result[50, 50]
+
+    # Expected center after clamping near right edge is roughly (75, 50)
+    assert abs(int(center_pixel[2]) - 75) <= 1  # red channel encodes x
+    assert abs(int(center_pixel[1]) - 50) <= 1  # green channel encodes y
+
+
+def test_autozoom_smoothing_behavior():
+    frame = _gradient_frame(100, 100)
+    move_data = {
+        0: (0.2, 0.2, 0, "", 0),
+        1: (0.8, 0.8, 0, "", 0),
+    }
+
+    zoom = transforms.AutoZoom(
+        move_data=move_data, zoom_factor=2.0, pan_speed=0.5, smoothing=1.0, edge_margin=0
+    )
+
+    out0 = zoom(input=frame.copy(), start_frame=0)["input"]
+    center0 = out0[50, 50]
+    assert abs(int(center0[2]) - 35) <= 1
+
+    out1 = zoom(input=frame.copy(), start_frame=1)["input"]
+    center1 = out1[50, 50]
+    assert abs(int(center1[2]) - 57) <= 1
+    # Ensure smoothing prevented jumping directly to target (80)
+    assert center1[2] < 70
+

--- a/tests/test_click_highlight.py
+++ b/tests/test_click_highlight.py
@@ -3,6 +3,31 @@ import sys
 import importlib.util
 
 import numpy as np
+import types
+
+fake_cv2 = types.SimpleNamespace()
+
+def _resize(img, size, interpolation=None):
+    from PIL import Image
+
+    return np.array(Image.fromarray(img).resize(size[::-1], Image.BILINEAR))
+
+def _circle(img, center, radius, color, thickness=-1, lineType=None):
+    yy, xx = np.ogrid[:img.shape[0], :img.shape[1]]
+    mask = (xx - center[0]) ** 2 + (yy - center[1]) ** 2 <= radius ** 2
+    img[mask] = color
+    return img
+
+def _addWeighted(a, alpha, b, beta, gamma):
+    return (a * alpha + b * beta + gamma).astype(a.dtype)
+
+fake_cv2.resize = _resize
+fake_cv2.circle = _circle
+fake_cv2.addWeighted = _addWeighted
+fake_cv2.INTER_LINEAR = 1
+fake_cv2.LINE_AA = 1
+
+sys.modules.setdefault("cv2", fake_cv2)
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 


### PR DESCRIPTION
## Summary
- implement `AutoZoom` transform to crop around cursor, interpolate motion, and honor keyframe overrides
- add unit tests verifying auto-zoom cropping and smoothing behaviour
- stub minimal cv2 functions in tests for headless execution

## Testing
- `pytest -q`