### PR TITLE
Add auto zoom & click highlight toggles

### DIFF
--- a/screenvivid/models/utils/transforms.py
+++ b/screenvivid/models/utils/transforms.py
@@ -39,6 +39,13 @@ class Compose(BaseTransform):
     def get(self, key, default=None):
         return self.transforms.get(key, default)
 
+
+class Identity(BaseTransform):
+    """A no-op transform used to disable pipeline stages."""
+
+    def __call__(self, **kwargs):
+        return kwargs
+
 class AspectRatio(BaseTransform):
     def __init__(self, aspect_ratio: str, screen_size: tuple):
         super().__init__()

--- a/screenvivid/models/video_controller.py
+++ b/screenvivid/models/video_controller.py
@@ -32,6 +32,9 @@ class VideoControllerModel(QObject):
     canRedoChanged = Signal(bool)
     outputSizeChanged = Signal()
     fpsChanged = Signal(int)
+    highlightEnabledChanged = Signal(bool)
+    autoZoomEnabledChanged = Signal(bool)
+    zoomFactorChanged = Signal(float)
 
     def __init__(self, frame_provider):
         super().__init__()
@@ -149,6 +152,36 @@ class VideoControllerModel(QObject):
         if self.video_processor.cursor_scale != value:
             self.video_processor.cursor_scale = value
             self.cursorScaleChanged.emit()
+
+    @Property(bool, notify=highlightEnabledChanged)
+    def highlightEnabled(self):
+        return self.video_processor.highlight_enabled
+
+    @highlightEnabled.setter
+    def highlightEnabled(self, value):
+        if self.video_processor.highlight_enabled != value:
+            self.video_processor.highlight_enabled = value
+            self.highlightEnabledChanged.emit(value)
+
+    @Property(bool, notify=autoZoomEnabledChanged)
+    def autoZoomEnabled(self):
+        return self.video_processor.auto_zoom_enabled
+
+    @autoZoomEnabled.setter
+    def autoZoomEnabled(self, value):
+        if self.video_processor.auto_zoom_enabled != value:
+            self.video_processor.auto_zoom_enabled = value
+            self.autoZoomEnabledChanged.emit(value)
+
+    @Property(float, notify=zoomFactorChanged)
+    def zoomFactor(self):
+        return self.video_processor.zoom_factor
+
+    @zoomFactor.setter
+    def zoomFactor(self, value):
+        if self.video_processor.zoom_factor != value:
+            self.video_processor.zoom_factor = value
+            self.zoomFactorChanged.emit(value)
 
     @Property(bool, notify=playingChanged)
     def is_playing(self):
@@ -297,8 +330,12 @@ class VideoProcessor(QObject):
         self._background = {"type": "wallpaper", "value": 1}
         self._device_pixel_ratio = 1.0
         self._cursor_scale = 1.0
+        self._highlight_enabled = False
+        self._auto_zoom_enabled = False
+        self._zoom_factor = 2.0
         self._transforms = None
         self._mouse_events = []
+        self._click_events = []
         self._region = None
         self._x_offset = None
         self._y_offset = None
@@ -382,6 +419,50 @@ class VideoProcessor(QObject):
         )
 
     @property
+    def highlight_enabled(self):
+        return self._highlight_enabled
+
+    @highlight_enabled.setter
+    def highlight_enabled(self, value):
+        self._highlight_enabled = value
+        if self._transforms is not None:
+            if value:
+                self._transforms["click_highlight"] = transforms.ClickHighlight(
+                    click_data=self._click_events
+                )
+            else:
+                self._transforms["click_highlight"] = transforms.Identity()
+
+    @property
+    def auto_zoom_enabled(self):
+        return self._auto_zoom_enabled
+
+    @auto_zoom_enabled.setter
+    def auto_zoom_enabled(self, value):
+        self._auto_zoom_enabled = value
+        if self._transforms is not None:
+            if value:
+                self._transforms["auto_zoom"] = transforms.AutoZoom(
+                    move_data=self._mouse_events,
+                    zoom_factor=self._zoom_factor,
+                )
+            else:
+                self._transforms["auto_zoom"] = transforms.Identity()
+
+    @property
+    def zoom_factor(self):
+        return self._zoom_factor
+
+    @zoom_factor.setter
+    def zoom_factor(self, value):
+        self._zoom_factor = value
+        if self._transforms is not None and self._auto_zoom_enabled:
+            self._transforms["auto_zoom"] = transforms.AutoZoom(
+                move_data=self._mouse_events,
+                zoom_factor=value,
+            )
+
+    @property
     def total_frames(self):
         return self._total_frames
 
@@ -429,6 +510,30 @@ class VideoProcessor(QObject):
     @mouse_events.setter
     def mouse_events(self, value):
         self._mouse_events = value
+        if self._transforms is not None:
+            self._transforms["cursor"] = transforms.Cursor(
+                move_data=self._mouse_events,
+                cursors_map=self._cursors_map,
+                offsets=(self._x_offset, self._y_offset),
+                scale=self._cursor_scale,
+            )
+            if self._auto_zoom_enabled:
+                self._transforms["auto_zoom"] = transforms.AutoZoom(
+                    move_data=self._mouse_events,
+                    zoom_factor=self._zoom_factor,
+                )
+
+    @property
+    def click_events(self):
+        return self._click_events
+
+    @click_events.setter
+    def click_events(self, value):
+        self._click_events = value
+        if self._transforms is not None and self._highlight_enabled:
+            self._transforms["click_highlight"] = transforms.ClickHighlight(
+                click_data=self._click_events
+            )
 
     @property
     def current_frame(self):
@@ -471,8 +576,9 @@ class VideoProcessor(QObject):
             self._start_frames.append(0)
             self._end_frames.append(self.total_frames)
 
-            self._mouse_events = metadata.get("mouse_events", {}).get("move", {}) if metadata else {}
+            self.mouse_events = metadata.get("mouse_events", {}).get("move", {}) if metadata else {}
             self._cursors_map = metadata.get("mouse_events", {}).get("cursors_map", {}) if metadata else {}
+            self.click_events = metadata.get("mouse_events", {}).get("click", []) if metadata else []
             self._region = metadata.get("region", []) if metadata else []
 
             if self._region:
@@ -485,7 +591,19 @@ class VideoProcessor(QObject):
             screen_size = int(screen_width * self._device_pixel_ratio), int(screen_height * self._device_pixel_ratio)
             self._transforms = transforms.Compose({
                 "aspect_ratio": transforms.AspectRatio(self._aspect_ratio, screen_size),
-                "cursor": transforms.Cursor(move_data=self._mouse_events, cursors_map=self._cursors_map, offsets=(x_offset, y_offset), scale=self._cursor_scale),
+                "auto_zoom": transforms.AutoZoom(
+                    move_data=self._mouse_events,
+                    zoom_factor=self._zoom_factor,
+                ) if self._auto_zoom_enabled else transforms.Identity(),
+                "click_highlight": transforms.ClickHighlight(
+                    click_data=self._click_events
+                ) if self._highlight_enabled else transforms.Identity(),
+                "cursor": transforms.Cursor(
+                    move_data=self._mouse_events,
+                    cursors_map=self._cursors_map,
+                    offsets=(x_offset, y_offset),
+                    scale=self._cursor_scale,
+                ),
                 "padding": transforms.Padding(padding=self.padding),
                 # "inset": transforms.Inset(inset=self.inset, color=(0, 0, 0)),
                 "border_shadow": transforms.BorderShadow(border_radius=self.border_radius),

--- a/tests/test_autozoom.py
+++ b/tests/test_autozoom.py
@@ -86,3 +86,20 @@ def test_autozoom_smoothing_behavior():
     # Ensure smoothing prevented jumping directly to target (80)
     assert center1[2] < 70
 
+
+def test_autozoom_can_be_disabled():
+    frame = _gradient_frame(100, 100)
+    move_data = {0: (0.8, 0.5, 0, "", 0)}
+
+    enabled = transforms.Compose({
+        "auto_zoom": transforms.AutoZoom(move_data=move_data, zoom_factor=2.0)
+    })
+    disabled = transforms.Compose({"auto_zoom": transforms.Identity()})
+
+    result_enabled = enabled(input=frame.copy(), start_frame=0)["input"]
+    result_disabled = disabled(input=frame.copy(), start_frame=0)["input"]
+
+    # Enabled transform should alter the frame while disabled returns original
+    assert not np.array_equal(result_enabled, frame)
+    assert np.array_equal(result_disabled, frame)
+

--- a/tests/test_click_highlight.py
+++ b/tests/test_click_highlight.py
@@ -57,3 +57,19 @@ def test_click_highlight_renders_at_coordinates():
     # After duration, highlight should vanish
     result = highlight(input=frame.copy(), start_frame=3)
     assert (result["input"][50, 50] == [0, 0, 0]).all()
+
+
+def test_click_highlight_can_be_disabled():
+    frame = np.zeros((100, 100, 3), dtype=np.uint8)
+    click_data = [(0.5, 0.5, 0, "left", "press", 0.0)]
+
+    enabled = transforms.Compose({
+        "highlight": transforms.ClickHighlight(click_data=click_data, color=(255, 0, 0))
+    })
+    disabled = transforms.Compose({"highlight": transforms.Identity()})
+
+    result_enabled = enabled(input=frame.copy(), start_frame=0)["input"]
+    result_disabled = disabled(input=frame.copy(), start_frame=0)["input"]
+
+    assert result_enabled[50, 50, 2] > 0
+    assert (result_disabled[50, 50] == [0, 0, 0]).all()


### PR DESCRIPTION
## Summary
- expose `highlightEnabled`, `autoZoomEnabled`, and `zoomFactor` on the video controller
- pass click data into processing pipeline and compose ClickHighlight + AutoZoom transforms
- add identity transform and tests covering enabling/disabling of new stages

## Testing
- `pytest -q`
