### PR TITLE
Add highlight and zoom editing controls

### DIFF
--- a/screenvivid/models/video_controller.py
+++ b/screenvivid/models/video_controller.py
@@ -33,6 +33,8 @@ class VideoControllerModel(QObject):
     outputSizeChanged = Signal()
     fpsChanged = Signal(int)
     highlightEnabledChanged = Signal(bool)
+    highlightColorChanged = Signal(str)
+    highlightRadiusChanged = Signal(int)
     autoZoomEnabledChanged = Signal(bool)
     zoomFactorChanged = Signal(float)
 
@@ -162,6 +164,26 @@ class VideoControllerModel(QObject):
         if self.video_processor.highlight_enabled != value:
             self.video_processor.highlight_enabled = value
             self.highlightEnabledChanged.emit(value)
+
+    @Property(str, notify=highlightColorChanged)
+    def highlightColor(self):
+        return self.video_processor.highlight_color
+
+    @highlightColor.setter
+    def highlightColor(self, value):
+        if self.video_processor.highlight_color != value:
+            self.video_processor.highlight_color = value
+            self.highlightColorChanged.emit(value)
+
+    @Property(int, notify=highlightRadiusChanged)
+    def highlightRadius(self):
+        return self.video_processor.highlight_radius
+
+    @highlightRadius.setter
+    def highlightRadius(self, value):
+        if self.video_processor.highlight_radius != value:
+            self.video_processor.highlight_radius = value
+            self.highlightRadiusChanged.emit(value)
 
     @Property(bool, notify=autoZoomEnabledChanged)
     def autoZoomEnabled(self):
@@ -331,6 +353,8 @@ class VideoProcessor(QObject):
         self._device_pixel_ratio = 1.0
         self._cursor_scale = 1.0
         self._highlight_enabled = False
+        self._highlight_color = "#ffcc00"
+        self._highlight_radius = 20
         self._auto_zoom_enabled = False
         self._zoom_factor = 2.0
         self._transforms = None
@@ -428,10 +452,40 @@ class VideoProcessor(QObject):
         if self._transforms is not None:
             if value:
                 self._transforms["click_highlight"] = transforms.ClickHighlight(
-                    click_data=self._click_events
+                    click_data=self._click_events,
+                    color=self._highlight_color,
+                    radius=self._highlight_radius,
                 )
             else:
                 self._transforms["click_highlight"] = transforms.Identity()
+
+    @property
+    def highlight_color(self):
+        return self._highlight_color
+
+    @highlight_color.setter
+    def highlight_color(self, value):
+        self._highlight_color = value
+        if self._transforms is not None and self._highlight_enabled:
+            self._transforms["click_highlight"] = transforms.ClickHighlight(
+                click_data=self._click_events,
+                color=value,
+                radius=self._highlight_radius,
+            )
+
+    @property
+    def highlight_radius(self):
+        return self._highlight_radius
+
+    @highlight_radius.setter
+    def highlight_radius(self, value):
+        self._highlight_radius = value
+        if self._transforms is not None and self._highlight_enabled:
+            self._transforms["click_highlight"] = transforms.ClickHighlight(
+                click_data=self._click_events,
+                color=self._highlight_color,
+                radius=value,
+            )
 
     @property
     def auto_zoom_enabled(self):
@@ -532,7 +586,9 @@ class VideoProcessor(QObject):
         self._click_events = value
         if self._transforms is not None and self._highlight_enabled:
             self._transforms["click_highlight"] = transforms.ClickHighlight(
-                click_data=self._click_events
+                click_data=self._click_events,
+                color=self._highlight_color,
+                radius=self._highlight_radius,
             )
 
     @property
@@ -596,7 +652,9 @@ class VideoProcessor(QObject):
                     zoom_factor=self._zoom_factor,
                 ) if self._auto_zoom_enabled else transforms.Identity(),
                 "click_highlight": transforms.ClickHighlight(
-                    click_data=self._click_events
+                    click_data=self._click_events,
+                    color=self._highlight_color,
+                    radius=self._highlight_radius,
                 ) if self._highlight_enabled else transforms.Identity(),
                 "cursor": transforms.Cursor(
                     move_data=self._mouse_events,

--- a/screenvivid/qml/studio/ControlButtons.qml
+++ b/screenvivid/qml/studio/ControlButtons.qml
@@ -124,6 +124,28 @@ Item {
                     icon.color: "#e8eaed"
                     onClicked: videoController.next_frame()
                 }
+                ToolButton {
+                    icon.source: "qrc:/resources/icons/zoom.svg"
+                    icon.color: videoController.autoZoomEnabled ? "#e8eaed" : "#555555"
+                    shortcut: "Z"
+                    onClicked: videoController.autoZoomEnabled = !videoController.autoZoomEnabled
+                    ToolTip {
+                        visible: parent.hovered
+                        text: qsTr("Toggle Auto Zoom (Z)")
+                        background: Rectangle { color: "#1d1d1d"; radius: 10 }
+                    }
+                }
+                ToolButton {
+                    icon.source: "qrc:/resources/icons/mouse.svg"
+                    icon.color: videoController.highlightEnabled ? "#e8eaed" : "#555555"
+                    shortcut: "H"
+                    onClicked: videoController.highlightEnabled = !videoController.highlightEnabled
+                    ToolTip {
+                        visible: parent.hovered
+                        text: qsTr("Toggle Click Highlight (H)")
+                        background: Rectangle { color: "#1d1d1d"; radius: 10 }
+                    }
+                }
             }
         }
 

--- a/screenvivid/qml/studio/VideoEdit.qml
+++ b/screenvivid/qml/studio/VideoEdit.qml
@@ -1,5 +1,6 @@
 import QtQuick 6.7
 import QtQuick.Controls 6.7
+import QtQuick.Dialogs 6.7
 
 Rectangle {
     id: videoEdit
@@ -10,7 +11,10 @@ Rectangle {
 
     Flickable {
         id: scrollView
-        anchors.fill: parent
+        anchors.left: parent.left
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        anchors.right: settingsPanel.left
         contentWidth: studioWindow.fps * studioWindow.videoLen * studioWindow.pixelsPerFrame + 200
         contentHeight: parent.height
         property real currentScrollX: 0
@@ -100,6 +104,80 @@ Rectangle {
                         scrollView.contentX = newContentX
                     }
                 }
+            }
+        }
+    }
+
+    Rectangle {
+        id: settingsPanel
+        width: 200
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        anchors.right: parent.right
+        color: "#1e2228"
+
+        Column {
+            anchors.fill: parent
+            anchors.margins: 10
+            spacing: 10
+
+            CheckBox {
+                text: qsTr("Click Highlight")
+                checked: videoController.highlightEnabled
+                onToggled: videoController.highlightEnabled = checked
+            }
+
+            CheckBox {
+                text: qsTr("Auto Zoom")
+                checked: videoController.autoZoomEnabled
+                onToggled: videoController.autoZoomEnabled = checked
+            }
+
+            Rectangle {
+                id: previewBox
+                width: parent.width
+                height: 80
+                color: "#2c313c"
+                radius: 4
+
+                Rectangle {
+                    width: videoController.highlightRadius * 2
+                    height: videoController.highlightRadius * 2
+                    radius: videoController.highlightRadius
+                    color: videoController.highlightColor
+                    opacity: 0.6
+                    anchors.centerIn: parent
+                }
+            }
+
+            Button {
+                id: colorButton
+                text: qsTr("Highlight Color")
+                onClicked: colorDialog.open()
+                background: Rectangle {
+                    color: videoController.highlightColor
+                    radius: 4
+                }
+            }
+
+            ColorDialog {
+                id: colorDialog
+                selectedColor: videoController.highlightColor
+                onAccepted: videoController.highlightColor = selectedColor
+            }
+
+            Text { text: qsTr("Radius") ; color: "#AAAAAA" }
+            Slider {
+                from: 5; to: 100; stepSize: 1
+                value: videoController.highlightRadius
+                onValueChanged: videoController.highlightRadius = value
+            }
+
+            Text { text: qsTr("Zoom Factor") ; color: "#AAAAAA" }
+            Slider {
+                from: 1.0; to: 5.0; stepSize: 0.1
+                value: videoController.zoomFactor
+                onValueChanged: videoController.zoomFactor = value
             }
         }
     }


### PR DESCRIPTION
## Summary
- Expose highlight color and radius plus zoom toggle in `VideoControllerModel`
- Add sidebar to `VideoEdit` for enabling click highlights and adjusting color, radius, and zoom factor
- Provide zoom/highlight toggle buttons with shortcuts and tooltips in `ControlButtons`

## Testing
- `pytest`