### PR TITLE
Add click markers and zoom keyframe support

### DIFF
--- a/screenvivid/models/video_controller.py
+++ b/screenvivid/models/video_controller.py
@@ -37,6 +37,8 @@ class VideoControllerModel(QObject):
     highlightRadiusChanged = Signal(int)
     autoZoomEnabledChanged = Signal(bool)
     zoomFactorChanged = Signal(float)
+    clickEventsChanged = Signal()
+    zoomKeyframesChanged = Signal()
 
     def __init__(self, frame_provider):
         super().__init__()
@@ -205,6 +207,34 @@ class VideoControllerModel(QObject):
             self.video_processor.zoom_factor = value
             self.zoomFactorChanged.emit(value)
 
+    @Property('QVariantList', notify=clickEventsChanged)
+    def clickEvents(self):
+        return self.video_processor.click_events
+
+    @clickEvents.setter
+    def clickEvents(self, value):
+        self.video_processor.click_events = value
+        self.clickEventsChanged.emit()
+
+    @Property('QVariantMap', notify=zoomKeyframesChanged)
+    def zoomKeyframes(self):
+        return self.video_processor.zoom_keyframes
+
+    @zoomKeyframes.setter
+    def zoomKeyframes(self, value):
+        self.video_processor.zoom_keyframes = value
+        self.zoomKeyframesChanged.emit()
+
+    @Slot(int, float, float, float)
+    def add_zoom_keyframe(self, frame, x, y, zoom):
+        self.video_processor.add_zoom_keyframe(frame, x, y, zoom)
+        self.zoomKeyframesChanged.emit()
+
+    @Slot(int, float, float, float)
+    def update_zoom_keyframe(self, frame, x, y, zoom):
+        self.video_processor.update_zoom_keyframe(frame, x, y, zoom)
+        self.zoomKeyframesChanged.emit()
+
     @Property(bool, notify=playingChanged)
     def is_playing(self):
         return self.video_processor.is_playing
@@ -251,7 +281,11 @@ class VideoControllerModel(QObject):
     def load_video(self, path, metadata):
         self.video_path = path
         self.is_recording_video = metadata["recording"]
-        return self.video_processor.load_video(path, metadata)
+        success = self.video_processor.load_video(path, metadata)
+        if success:
+            self.clickEventsChanged.emit()
+            self.zoomKeyframesChanged.emit()
+        return success
 
     @Slot()
     def toggle_play_pause(self):
@@ -360,6 +394,7 @@ class VideoProcessor(QObject):
         self._transforms = None
         self._mouse_events = []
         self._click_events = []
+        self._zoom_keyframes = {}
         self._region = None
         self._x_offset = None
         self._y_offset = None
@@ -499,6 +534,7 @@ class VideoProcessor(QObject):
                 self._transforms["auto_zoom"] = transforms.AutoZoom(
                     move_data=self._mouse_events,
                     zoom_factor=self._zoom_factor,
+                    keyframes=self._zoom_keyframes,
                 )
             else:
                 self._transforms["auto_zoom"] = transforms.Identity()
@@ -514,6 +550,7 @@ class VideoProcessor(QObject):
             self._transforms["auto_zoom"] = transforms.AutoZoom(
                 move_data=self._mouse_events,
                 zoom_factor=value,
+                keyframes=self._zoom_keyframes,
             )
 
     @property
@@ -575,6 +612,7 @@ class VideoProcessor(QObject):
                 self._transforms["auto_zoom"] = transforms.AutoZoom(
                     move_data=self._mouse_events,
                     zoom_factor=self._zoom_factor,
+                    keyframes=self._zoom_keyframes,
                 )
 
     @property
@@ -590,6 +628,28 @@ class VideoProcessor(QObject):
                 color=self._highlight_color,
                 radius=self._highlight_radius,
             )
+
+    @property
+    def zoom_keyframes(self):
+        return self._zoom_keyframes
+
+    @zoom_keyframes.setter
+    def zoom_keyframes(self, value):
+        self._zoom_keyframes = value
+        if self._transforms is not None and self._auto_zoom_enabled:
+            self._transforms["auto_zoom"] = transforms.AutoZoom(
+                move_data=self._mouse_events,
+                zoom_factor=self._zoom_factor,
+                keyframes=self._zoom_keyframes,
+            )
+
+    def add_zoom_keyframe(self, frame, x, y, zoom):
+        self._zoom_keyframes[frame] = (x, y, zoom)
+        if self._transforms is not None and self._auto_zoom_enabled:
+            self._transforms["auto_zoom"].keyframes = self._zoom_keyframes
+
+    def update_zoom_keyframe(self, frame, x, y, zoom):
+        self.add_zoom_keyframe(frame, x, y, zoom)
 
     @property
     def current_frame(self):
@@ -635,6 +695,7 @@ class VideoProcessor(QObject):
             self.mouse_events = metadata.get("mouse_events", {}).get("move", {}) if metadata else {}
             self._cursors_map = metadata.get("mouse_events", {}).get("cursors_map", {}) if metadata else {}
             self.click_events = metadata.get("mouse_events", {}).get("click", []) if metadata else []
+            self.zoom_keyframes = metadata.get("zoom_keyframes", {}) if metadata else {}
             self._region = metadata.get("region", []) if metadata else []
 
             if self._region:
@@ -650,6 +711,7 @@ class VideoProcessor(QObject):
                 "auto_zoom": transforms.AutoZoom(
                     move_data=self._mouse_events,
                     zoom_factor=self._zoom_factor,
+                    keyframes=self._zoom_keyframes,
                 ) if self._auto_zoom_enabled else transforms.Identity(),
                 "click_highlight": transforms.ClickHighlight(
                     click_data=self._click_events,

--- a/screenvivid/qml/studio/TimeSlider.qml
+++ b/screenvivid/qml/studio/TimeSlider.qml
@@ -9,6 +9,14 @@ Item {
     property string color: "#484554"
     property bool animationEnabled: true // Property to enable/disable animation
 
+    function formatTime(frame) {
+        var fps = studioWindow.fps
+        var totalSeconds = frame / fps
+        var minutes = Math.floor(totalSeconds / 60)
+        var seconds = Math.floor(totalSeconds % 60)
+        return minutes.toString().padStart(2, '0') + ':' + seconds.toString().padStart(2, '0')
+    }
+
     Rectangle {
         id: timeSliderHead
         width: parent.width
@@ -18,7 +26,9 @@ Item {
         color: parent.color
 
         MouseArea {
+            id: headArea
             anchors.fill: parent
+            hoverEnabled: true
 
             drag {
                 target: timeSlider
@@ -32,6 +42,11 @@ Item {
                             timeSlider.x / studioWindow.pixelsPerFrame)
                 videoController.jump_to_frame(currentFrame)
             }
+        }
+
+        ToolTip {
+            visible: headArea.containsMouse
+            text: formatTime(Math.round(timeSlider.x / studioWindow.pixelsPerFrame))
         }
     }
 

--- a/screenvivid/qml/studio/Timeline.qml
+++ b/screenvivid/qml/studio/Timeline.qml
@@ -1,67 +1,99 @@
 import QtQuick 6.7
+import QtQuick.Controls 6.7
 import QtQuick.Controls.Material 6.7
 import QtQuick.Layouts 6.7
 
-// Timeline
-Repeater {
-    model: Math.ceil(studioWindow.videoLen) + 1
+Item {
+    id: timeline
+    width: studioWindow.fps * studioWindow.videoLen * studioWindow.pixelsPerFrame
+    height: 60
 
-    Item {
-        width: studioWindow.fps * studioWindow.pixelsPerFrame
-        height: 60
-        x: studioWindow.fps * studioWindow.pixelsPerFrame * index
-        // y: 10
+    function formatTime(frame) {
+        var fps = studioWindow.fps
+        var totalSeconds = frame / fps
+        var minutes = Math.floor(totalSeconds / 60)
+        var seconds = Math.floor(totalSeconds % 60)
+        return minutes.toString().padStart(2, '0') + ':' + seconds.toString().padStart(2, '0')
+    }
 
-        readonly property int timeLabelWidth: 20
+    Repeater {
+        model: Math.ceil(studioWindow.videoLen) + 1
 
-        Item {
-            width: parent.timeLabelWidth
-            height: parent.height
+        delegate: Item {
+            width: studioWindow.fps * studioWindow.pixelsPerFrame
+            height: 60
+            x: studioWindow.fps * studioWindow.pixelsPerFrame * index
 
-            ColumnLayout {
-                anchors.fill: parent
-                spacing: 10
+            readonly property int timeLabelWidth: 20
 
-                Item {
-                    Layout.fillHeight: true
-                    Layout.fillWidth: true
-                }
+            Item {
+                width: parent.timeLabelWidth
+                height: parent.height
 
-                Label {
-                    Layout.alignment: Qt.AlignCenter
-                    text: qsTr("" + index)
-                }
+                ColumnLayout {
+                    anchors.fill: parent
+                    spacing: 10
 
-                Item {
-                    Layout.alignment: Qt.AlignCenter
+                    Item { Layout.fillHeight: true; Layout.fillWidth: true }
 
-                    Rectangle {
-                        width: 4
-                        height: 4
-                        radius: 2
-                        color: "white"
-                        anchors.centerIn: parent
+                    Label {
+                        Layout.alignment: Qt.AlignCenter
+                        text: qsTr("" + index)
                     }
-                }
 
-                Item {
-                    Layout.fillHeight: true
-                    Layout.fillWidth: true
+                    Item {
+                        Layout.alignment: Qt.AlignCenter
+
+                        Rectangle {
+                            width: 4
+                            height: 4
+                            radius: 2
+                            color: "white"
+                            anchors.centerIn: parent
+                        }
+                    }
+
+                    Item { Layout.fillHeight: true; Layout.fillWidth: true }
+                }
+            }
+
+            MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                    var xPos = Math.max(0,
+                                        studioWindow.fps * studioWindow.pixelsPerFrame * index + mouseX
+                                        - parent.timeLabelWidth / 2)
+                    var currentFrame = Math.round(xPos / studioWindow.pixelsPerFrame)
+                    videoController.jump_to_frame(currentFrame)
                 }
             }
         }
-        MouseArea {
-            anchors.fill: parent
-            onClicked: {
-                var xPos = Math.max(
-                            0,
-                            studioWindow.fps * studioWindow.pixelsPerFrame * index + mouseX
-                            - parent.timeLabelWidth / 2)
-                var currentFrame = Math.round(
-                            xPos / studioWindow.pixelsPerFrame)
-                videoController.jump_to_frame(
-                            currentFrame)
+    }
+
+    Repeater {
+        model: videoController.clickEvents
+
+        delegate: Rectangle {
+            visible: modelData[4] === "press"
+            width: 4
+            height: 12
+            radius: 2
+            color: videoController.currentFrame === modelData[2] ? studioWindow.accentColor : "white"
+            x: modelData[2] * studioWindow.pixelsPerFrame - width / 2
+            anchors.bottom: parent.bottom
+
+            ToolTip {
+                visible: area.containsMouse
+                text: formatTime(modelData[2])
+            }
+
+            MouseArea {
+                id: area
+                anchors.fill: parent
+                hoverEnabled: true
+                onClicked: videoController.jump_to_frame(modelData[2])
             }
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- show click event markers on timeline and allow seeking via marker
- expose click events and zoom keyframes in VideoControllerModel with slots to add or edit
- add time formatting tooltip support for slider and markers

## Testing
- `pytest`
