### PR TITLE
Ensure export pipeline matches controller and test click highlights

### DIFF
--- a/screenvivid/models/export.py
+++ b/screenvivid/models/export.py
@@ -7,6 +7,8 @@ import threading
 import numpy as np
 from PIL import Image
 from PySide6.QtCore import Signal, QThread
+
+from screenvivid.models.utils import transforms
 from screenvivid.utils.general import get_os_name, get_ffmpeg_path
 from screenvivid.utils.logging import logger
 
@@ -20,6 +22,33 @@ class VideoReaderThread(QThread):
         self.stop_flag = stop_flag
         self.export_params = export_params
 
+        # Build transform pipeline similar to VideoControllerModel
+        self.transforms = transforms.Compose({
+            "aspect_ratio": transforms.AspectRatio(
+                export_params.get("aspect_ratio", "Auto"),
+                export_params.get("screen_size", (video_processor.frame_width, video_processor.frame_height)),
+            ),
+            "auto_zoom": transforms.AutoZoom(
+                move_data=export_params.get("move_data", {}),
+                zoom_factor=export_params.get("zoom_factor", 2.0),
+                keyframes=export_params.get("zoom_keyframes", {}),
+            ) if export_params.get("auto_zoom_enabled", False) else transforms.Identity(),
+            "click_highlight": transforms.ClickHighlight(
+                click_data=export_params.get("click_data", []),
+                color=export_params.get("highlight_color"),
+                radius=export_params.get("highlight_radius", 20),
+            ) if export_params.get("highlight_enabled", False) else transforms.Identity(),
+            "cursor": transforms.Cursor(
+                move_data=export_params.get("move_data", {}),
+                cursors_map=export_params.get("cursors_map", {}),
+                offsets=export_params.get("offsets", (None, None)),
+                scale=export_params.get("cursor_scale", 1.0),
+            ),
+            "padding": transforms.Padding(export_params.get("padding", 0)),
+            "border_shadow": transforms.BorderShadow(border_radius=export_params.get("border_radius", 0)),
+            "background": transforms.Background(export_params.get("background", {"type": "color", "value": "#000000"})),
+        })
+
     def run(self):
         output_size = tuple(self.export_params.get("output_size"))
 
@@ -28,21 +57,22 @@ class VideoReaderThread(QThread):
         self.video_processor.current_frame = self.video_processor.start_frame
 
         total_frames = self.video_processor.end_frame - self.video_processor.start_frame
-        for i in range(total_frames):
+        for _ in range(total_frames):
             if self.stop_flag.is_set():
                 break
 
             ret, frame = self.video_processor.video.read()
             if ret:
-                # Get processed frame (in RGB format)
-                processed_frame = self.video_processor.process_frame(frame)
+                processed_frame = self.transforms(
+                    input=frame,
+                    start_frame=self.video_processor.start_frame + self.video_processor.current_frame,
+                )
+                processed_frame = cv2.cvtColor(processed_frame, cv2.COLOR_BGR2RGB)
                 self.video_processor.current_frame += 1
 
-                # Resize frame if necessary
                 if processed_frame.shape[:2] != output_size:
                     processed_frame = cv2.resize(processed_frame, output_size)
 
-                # Push the processed frame to the queue
                 self.frame_queue.put(processed_frame)
             else:
                 break
@@ -50,7 +80,6 @@ class VideoReaderThread(QThread):
         self.video_processor.video.set(cv2.CAP_PROP_POS_FRAMES, current_frame)
         self.video_processor.current_frame = current_frame
 
-        # Signal that the reading is done
         self.frame_queue.put(None)
 
 # Codec-specific configurations
@@ -267,6 +296,7 @@ class FFmpegWriterThread(QThread):
             finally:
                 self.finished.emit()
 
+
 class ExportThread(QThread):
     progress = Signal(float)
     finished = Signal()
@@ -274,15 +304,45 @@ class ExportThread(QThread):
     def __init__(self, video_processor, export_params):
         super().__init__()
         self.video_processor = video_processor
-        self.export_params = export_params
-        # Increased queue size for better buffering
-        self.frame_queue = queue.Queue(maxsize=90)  # Buffer 3 second at 30fps
+
+        # Make a copy of export parameters and enrich with runtime configuration
+        self.export_params = dict(export_params)
+        vp = self.video_processor
+        self.export_params.setdefault("fps", vp.fps)
+        self.export_params.setdefault("output_size", (vp.frame_width, vp.frame_height))
+        self.export_params.setdefault("aspect_ratio", vp.aspect_ratio)
+        self.export_params.setdefault("padding", vp.padding)
+        self.export_params.setdefault("border_radius", vp.border_radius)
+        self.export_params.setdefault("background", vp.background)
+        self.export_params.setdefault("cursor_scale", vp.cursor_scale)
+        self.export_params.setdefault("highlight_enabled", vp.highlight_enabled)
+        self.export_params.setdefault("highlight_color", vp.highlight_color)
+        self.export_params.setdefault("highlight_radius", vp.highlight_radius)
+        self.export_params.setdefault("auto_zoom_enabled", vp.auto_zoom_enabled)
+        self.export_params.setdefault("zoom_factor", vp._zoom_factor)
+        self.export_params.setdefault("move_data", vp._mouse_events)
+        self.export_params.setdefault("click_data", vp._click_events)
+        self.export_params.setdefault("zoom_keyframes", vp._zoom_keyframes)
+        self.export_params.setdefault("cursors_map", vp._cursors_map)
+        self.export_params.setdefault("offsets", (vp._x_offset, vp._y_offset))
+        if vp._transforms is not None and vp._transforms.get("aspect_ratio"):
+            self.export_params.setdefault("screen_size", vp._transforms["aspect_ratio"].screen_size)
+        else:
+            self.export_params.setdefault("screen_size", (vp.frame_width, vp.frame_height))
+
+        # Cache cursor positions for quick lookup
+        move_data = self.export_params.get("move_data", {})
+        if isinstance(move_data, list):
+            self.export_params["move_data"] = {i: v for i, v in enumerate(move_data)}
+
+        # Queue used between reader and writer threads
+        self.frame_queue = queue.Queue(maxsize=90)
         self._stop_flag = threading.Event()
 
-        self.export_params["total_frames"] = self.video_processor.end_frame - self.video_processor.start_frame
+        self.export_params["total_frames"] = vp.end_frame - vp.start_frame
 
-        self.reader_thread = VideoReaderThread(video_processor, self.frame_queue, self._stop_flag, export_params)
-        self.writer_thread = FFmpegWriterThread(self.frame_queue, self._stop_flag, export_params)
+        self.reader_thread = VideoReaderThread(vp, self.frame_queue, self._stop_flag, self.export_params)
+        self.writer_thread = FFmpegWriterThread(self.frame_queue, self._stop_flag, self.export_params)
 
         self.writer_thread.progress.connect(self.progress.emit)
         self.writer_thread.finished.connect(self.finished.emit)

--- a/tests/test_export_integration.py
+++ b/tests/test_export_integration.py
@@ -1,0 +1,184 @@
+import sys
+import types
+import threading
+import queue
+
+import numpy as np
+
+# --- minimal cv2 mock -----------------------------------------------------
+fake_cv2 = types.SimpleNamespace()
+
+def _resize(img, size, interpolation=None):
+    from PIL import Image
+    return np.array(Image.fromarray(img).resize(size[::-1], Image.BILINEAR))
+
+def _circle(img, center, radius, color, thickness=-1, lineType=None):
+    yy, xx = np.ogrid[:img.shape[0], :img.shape[1]]
+    mask = (xx - center[0]) ** 2 + (yy - center[1]) ** 2 <= radius ** 2
+    img[mask] = color
+    return img
+
+def _addWeighted(a, alpha, b, beta, gamma):
+    return (a * alpha + b * beta + gamma).astype(a.dtype)
+
+def _cvtColor(img, code):
+    return img[:, :, ::-1]  # bgr <-> rgb swap
+
+def _copyMakeBorder(img, top, bottom, left, right, borderType, dst=None, value=0):
+    h, w = img.shape[:2]
+    if img.ndim == 2:
+        out = np.full((h + top + bottom, w + left + right), value, dtype=img.dtype)
+    else:
+        out = np.full((h + top + bottom, w + left + right, img.shape[2]), value, dtype=img.dtype)
+    out[top:top + h, left:left + w] = img
+    return out
+
+def _imread(path, flags=None):
+    return np.zeros((16, 16, 4), dtype=np.uint8)
+
+fake_cv2.resize = _resize
+fake_cv2.circle = _circle
+fake_cv2.addWeighted = _addWeighted
+fake_cv2.cvtColor = _cvtColor
+fake_cv2.copyMakeBorder = _copyMakeBorder
+fake_cv2.imread = _imread
+fake_cv2.COLOR_BGR2RGB = 1
+fake_cv2.CAP_PROP_POS_FRAMES = 1
+fake_cv2.INTER_LINEAR = 1
+fake_cv2.LINE_AA = 1
+fake_cv2.BORDER_CONSTANT = 0
+fake_cv2.IMREAD_UNCHANGED = -1
+fake_cv2.INTER_LANCZOS4 = 1
+
+sys.modules["cv2"] = fake_cv2
+
+import os
+import importlib
+import importlib.util
+import types
+
+
+class DummyVideoCapture:
+    def __init__(self, frames):
+        self.frames = frames
+        self.index = 0
+
+    def read(self):
+        if self.index < len(self.frames):
+            frame = self.frames[self.index]
+            self.index += 1
+            return True, frame.copy()
+        return False, None
+
+    def set(self, prop, value):
+        if prop == fake_cv2.CAP_PROP_POS_FRAMES:
+            self.index = int(value)
+
+
+class DummyVideoProcessor:
+    def __init__(self, frames):
+        self.video = DummyVideoCapture(frames)
+        self.current_frame = 0
+        self.start_frame = 0
+        self.end_frame = len(frames)
+        self.frame_width = frames[0].shape[1]
+        self.frame_height = frames[0].shape[0]
+        self.fps = 30
+
+        # configuration parameters
+        self.padding = 0
+        self.border_radius = 0
+        self.background = {"type": "color", "value": "#000000"}
+        self.cursor_scale = 1.0
+        self.highlight_enabled = True
+        self.highlight_color = "#ff0000"
+        self.highlight_radius = 5
+        self.auto_zoom_enabled = False
+        self._zoom_factor = 2.0
+        self._mouse_events = {}
+        self._click_events = [(0.5, 0.5, 0, "left", "press", 0.0)]
+        self._zoom_keyframes = {}
+        self._cursors_map = {}
+        self._x_offset = None
+        self._y_offset = None
+        self.aspect_ratio = "Auto"
+        self._transforms = None
+
+
+def test_export_renders_click_highlights():
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    sys.path.insert(0, repo_root)
+
+    screenvivid_pkg = types.ModuleType("screenvivid")
+    models_pkg = types.ModuleType("screenvivid.models")
+    screenvivid_pkg.models = models_pkg
+    sys.modules["screenvivid"] = screenvivid_pkg
+    sys.modules["screenvivid.models"] = models_pkg
+
+    utils_root = types.ModuleType("screenvivid.utils")
+    sys.modules["screenvivid.utils"] = utils_root
+
+    logging_path = os.path.join(repo_root, "screenvivid", "utils", "logging.py")
+    spec_l = importlib.util.spec_from_file_location("screenvivid.utils.logging", logging_path)
+    logging_mod = importlib.util.module_from_spec(spec_l)
+    spec_l.loader.exec_module(logging_mod)
+    utils_root.logging = logging_mod
+    sys.modules["screenvivid.utils.logging"] = logging_mod
+
+    general_path = os.path.join(repo_root, "screenvivid", "utils", "general.py")
+    spec_g = importlib.util.spec_from_file_location("screenvivid.utils.general", general_path)
+    general = importlib.util.module_from_spec(spec_g)
+    spec_g.loader.exec_module(general)
+    utils_root.general = general
+    sys.modules["screenvivid.utils.general"] = general
+
+    transforms_path = os.path.join(repo_root, "screenvivid", "models", "utils", "transforms.py")
+    spec_t = importlib.util.spec_from_file_location("screenvivid.models.utils.transforms", transforms_path)
+    transforms = importlib.util.module_from_spec(spec_t)
+    spec_t.loader.exec_module(transforms)
+    utils_pkg = types.ModuleType("screenvivid.models.utils")
+    utils_pkg.transforms = transforms
+    sys.modules["screenvivid.models.utils"] = utils_pkg
+    sys.modules["screenvivid.models.utils.transforms"] = transforms
+
+    export_path = os.path.join(repo_root, "screenvivid", "models", "export.py")
+    spec = importlib.util.spec_from_file_location("screenvivid.models.export", export_path)
+    export = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(export)
+
+    try:
+        frames = [np.zeros((100, 100, 3), dtype=np.uint8) for _ in range(3)]
+        vp = DummyVideoProcessor(frames)
+
+        export_params = {
+            "fps": vp.fps,
+            "output_size": (vp.frame_width, vp.frame_height),
+            "highlight_enabled": True,
+            "highlight_color": "#ff0000",
+            "highlight_radius": 5,
+            "screen_size": (1000, 1000),
+            "click_data": vp._click_events,
+        }
+
+        q = queue.Queue()
+        stop_flag = threading.Event()
+        reader = export.VideoReaderThread(vp, q, stop_flag, export_params)
+        reader.run()
+
+        out_frames = []
+        while True:
+            f = q.get()
+            if f is None:
+                break
+            out_frames.append(f)
+
+        assert out_frames, "no frames exported"
+        # Click was at center, highlight color converted to RGB -> red channel > 0
+        assert out_frames[0][50, 50, 0] > 0
+    finally:
+        for name in [
+            "screenvivid.utils", "screenvivid.utils.logging", "screenvivid.utils.general",
+            "screenvivid.models.utils", "screenvivid.models.utils.transforms",
+            "screenvivid.models.export",
+        ]:
+            sys.modules.pop(name, None)


### PR DESCRIPTION
## Summary
- Build full transform pipeline in `VideoReaderThread` matching `VideoControllerModel`, including ClickHighlight and AutoZoom
- Pass all controller configuration and mouse/click data through `export_params` with simple cursor caching
- Add integration test exporting a clip with click data verifying highlight rendering

## Testing
- `pytest -q`
